### PR TITLE
More joinField features

### DIFF
--- a/documentation/manual/home.textile
+++ b/documentation/manual/home.textile
@@ -22,10 +22,15 @@ public class Folder extends Model {
     @Field
     @Column(unique=true)
     public Integer poseidonNumber; 
+
     @Field
     public String object;
 
-The **@Field** annotation currently supports only primitive types.
+    @Field(joinField = {"name", "group.name"})
+	@ManyToOne
+	public User owner;
+
+The **@Field** annotation supports indexing fields across joins, as shown in the example above for the **owner** parameter. The searchable fields for this example will be **poseidonNumber**, **object**, **owner.name**, and **owner.group.name**.
 
 h2. <a> Search the objects </a>
 

--- a/documentation/manual/home.textile
+++ b/documentation/manual/home.textile
@@ -27,8 +27,8 @@ public class Folder extends Model {
     public String object;
 
     @Field(joinField = {"name", "group.name"})
-	@ManyToOne
-	public User owner;
+    @ManyToOne
+    public User owner;
 
 The **@Field** annotation supports indexing fields across joins, as shown in the example above for the **owner** parameter. The searchable fields for this example will be **poseidonNumber**, **object**, **owner.name**, and **owner.group.name**.
 

--- a/src/play/modules/search/Field.java
+++ b/src/play/modules/search/Field.java
@@ -14,5 +14,5 @@ public @interface Field {
     boolean stored() default false;
     boolean tokenize() default true;
     boolean sortable() default false;
-    String[] joinField() default "";
+    String[] joinField() default {};
 }

--- a/src/play/modules/search/Field.java
+++ b/src/play/modules/search/Field.java
@@ -14,5 +14,5 @@ public @interface Field {
     boolean stored() default false;
     boolean tokenize() default true;
     boolean sortable() default false;
-    String joinField() default "";
+    String[] joinField() default "";
 }

--- a/src/play/modules/search/store/ConvertionUtils.java
+++ b/src/play/modules/search/store/ConvertionUtils.java
@@ -7,7 +7,6 @@ import javax.persistence.Id;
 import javax.persistence.ManyToOne;
 
 import org.apache.lucene.document.Document;
-import org.apache.lucene.document.Field;
 
 import play.Logger;
 import play.data.binding.Binder;
@@ -25,7 +24,7 @@ import play.modules.search.Indexed;
 public class ConvertionUtils {
     private static final String JAVA_MEMBER_ACCESSOR = ".";
 
-	/**
+    /**
      * Examines a JPABase object and creates the corresponding Lucene Document
      * 
      * @param object to examine, expected a JPABase object
@@ -63,12 +62,17 @@ public class ConvertionUtils {
     }
 
     static void traverseJoinFields(DocumentBuilder builder, String indexName, String prefix, play.modules.search.Field index, JPABase object) throws Exception {
+        if (object == null) {
+            return;
+        }
+
         for (java.lang.reflect.Field field : object.getClass().getFields()) {
             String name = prefix + field.getName();
             if (isJoinFieldMatch(index.joinField(), name)) {
                 if (JPABase.class.isAssignableFrom(field.getType())) {
                     traverseJoinFields(builder, indexName, name + JAVA_MEMBER_ACCESSOR, index, (JPABase ) field.get(object));
-                } else if (Arrays.asList(index.joinField()).contains(name)) {
+                }
+                if (Arrays.asList(index.joinField()).contains(name)) {
                     builder.addField(indexName + JAVA_MEMBER_ACCESSOR + name, valueOf(object, field), index);
                 }
             }

--- a/src/play/modules/search/store/DocumentBuilder.java
+++ b/src/play/modules/search/store/DocumentBuilder.java
@@ -1,0 +1,35 @@
+package play.modules.search.store;
+
+import org.apache.lucene.document.Document;
+import org.apache.lucene.document.Field;
+
+public class DocumentBuilder {
+    protected Document document = new Document();
+
+    protected StringBuffer allValue = new StringBuffer();
+
+    public DocumentBuilder(String docId) {
+        document.add(new Field("_docID", docId, Field.Store.YES, Field.Index.UN_TOKENIZED));
+    }
+
+    public void addField(String name, String value, play.modules.search.Field index) {
+        if (value == null) {
+            return;
+        }
+
+        document.add(new Field(name, value, index.stored() ? Field.Store.YES : Field.Store.NO,
+                        index.tokenize() ? Field.Index.TOKENIZED : Field.Index.UN_TOKENIZED));
+
+        if (index.tokenize() && index.sortable()) {
+            document.add(new Field(name + "_untokenized", value, index.stored() ? Field.Store.YES : Field.Store.NO,
+                            Field.Index.UN_TOKENIZED));
+        }
+
+        allValue.append(value).append(' ');
+    }
+
+    public Document toDocument() {
+        document.add(new Field("allfield", allValue.toString(), Field.Store.NO, Field.Index.TOKENIZED));
+        return document;
+    }
+}


### PR DESCRIPTION
Hi!

Nice module!

I made some changes that I hope can be integrated. The basic idea is support for several joinFields and nested joinFields. To be able to support these changes I found it necessary to add namespacing to the indexed names of joinFields.

Here are the changes in detail:

(1) A field with the joinField parameter gets indexed as {field}.{joinField} instead of just {joinField} (as in previous versions). Example: '@Field(joinField = "name") public User user' gives an indexed field named "user.name".

(2) Multiple joinFields are allowed. Example: '@Field(joinField = {"name", "email"}) public User user' gives two indexed fields named "user.name" and "user.email".

(3) Nested joinFields are allowed. Example: '@Field(joinField = {"city.name", "city.country.name"}) public User user' gives two indexed fields named "user.city.name" and "user.city.country.name". The nesting can be arbitrarily deep. No changes to the referenced models are needed.

The namespacing change will cause the Lucene index and queries to be backwards incompatible, so models need to be reindexed and queries need to be fixed. Existing model annotations should however work without any changes (as a string is interpreted as a string array with one element in annotation parameters).

Check out the commit messages and code for (even) more details.

By the way, I couldn't find any tests, so I created my own repository with tests for the module (currently only containing tests for my changes): https://github.com/hakos/play-search-test

Best regards,

Håkon Sandsmark
