### PR TITLE
On Windows systems I'm using the file renaming fails unless indexWriter is closed. 

### DIFF
--- a/src/play/modules/search/store/FilesystemStore.java
+++ b/src/play/modules/search/store/FilesystemStore.java
@@ -215,7 +215,8 @@ public class FilesystemStore implements Store {
                 indexWriter.addDocument(document);
             }
 
-            getIndexWriter(index).commit();
+            indexWriter.commit();
+            indexWriter.close();
             dirtyReader(index);
             getIndexSearcher(name).close();
             indexSearchers.remove(name);


### PR DESCRIPTION
Fixed problem where lock on the indexWriter is not released and the renaming of temporary directory is unsuccessful, causing empty index
