### PR TITLE
Close old IndexWriter before rename folder &  Add method fetchFromIndex for Query to improve performance in some cases

### DIFF
--- a/src/play/modules/search/store/FilesystemStore.java
+++ b/src/play/modules/search/store/FilesystemStore.java
@@ -211,6 +211,7 @@ public class FilesystemStore implements Store {
             }
 
             getIndexWriter(index).commit();
+            getIndexWriter(index).close();
             dirtyReader(index);
             getIndexSearcher(name).close();
             indexSearchers.remove(name);


### PR DESCRIPTION
This first commit is for resolving the rename issue under windows platform.
And the second commit is adding method fetchFromIndex for Query. Currently it always fetch field value from DB. So one search operation will invoke one lucene search and several db read. But often if we only need the fields which are stored in Lucene, then we do not need to invoke db read, just read it from index.
